### PR TITLE
Replacing the outcomes wording by expenses

### DIFF
--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -43,13 +43,13 @@ function Dashboard({ entries }) {
               <AddEntry entryType='income' />
             </Route>
             <Route path={`${match.url}/add-expense`}>
-              <AddEntry entryType='outcome' />
+              <AddEntry entryType='expense' />
             </Route>
             <Route path={`${match.url}/incomes`}>
               <EntrySummaryWithFilter entryType='income' />
             </Route>
-            <Route path={`${match.url}/outcomes`}>
-              <EntrySummaryWithFilter entryType='outcome' />
+            <Route path={`${match.url}/expenses`}>
+              <EntrySummaryWithFilter entryType='expense' />
             </Route>
             <Route path={`${match.url}/summary`}>
               <Summary entries={entries} />
@@ -78,7 +78,7 @@ Dashboard.propTypes = {
         category: PropTypes.string.isRequired
       }).isRequired
     ).isRequired,
-    outcomes: PropTypes.arrayOf(
+    expenses: PropTypes.arrayOf(
       PropTypes.shape({
         ammount: PropTypes.number.isRequired,
         description: PropTypes.string.isRequired,

--- a/src/components/Dashboard/Dashboard.test.js
+++ b/src/components/Dashboard/Dashboard.test.js
@@ -37,7 +37,7 @@ describe('Dashboard component test', () => {
     expect(DashboardInstance.state.entries.incomes).toStrictEqual([ newEntry, newEntry ]);
   })
 
-  it('addIncome: should add new income to the state outcomes', () => {
+  it('addIncome: should add new income to the state expenses', () => {
     act(() => {
       DashboardInstance.addIncome(newEntry);
       DashboardInstance.addIncome(newEntry);
@@ -47,25 +47,25 @@ describe('Dashboard component test', () => {
     expect(DashboardInstance.state.entries.incomes).toStrictEqual([ newEntry, newEntry ]);
   })
   
-  it('addOutcome: should add new outcome to the state outcomes', () => {
+  it('addExpense: should add new expense to the state expenses', () => {
     act(() => {
-      DashboardInstance.addOutcome(newEntry);
-      DashboardInstance.addOutcome(newEntry);
+      DashboardInstance.addExpense(newEntry);
+      DashboardInstance.addExpense(newEntry);
     });
 
-    expect(DashboardInstance.state.entries.outcomes.length).toBe(2);
-    expect(DashboardInstance.state.entries.outcomes).toStrictEqual([ newEntry, newEntry ]);
+    expect(DashboardInstance.state.entries.expenses.length).toBe(2);
+    expect(DashboardInstance.state.entries.expenses).toStrictEqual([ newEntry, newEntry ]);
   })
 
   it.only('getSum: should get the correct sum for entries added', () => {
     act(() => {
-      DashboardInstance.addOutcome(newEntry);
-      DashboardInstance.addOutcome(newEntry);
-      DashboardInstance.addOutcome(newEntry);
-      DashboardInstance.addOutcome(newEntry);
+      DashboardInstance.addExpense(newEntry);
+      DashboardInstance.addExpense(newEntry);
+      DashboardInstance.addExpense(newEntry);
+      DashboardInstance.addExpense(newEntry);
     });
 
-    const totalSum = DashboardInstance.getSum('outcomes');
+    const totalSum = DashboardInstance.getSum('expenses');
     expect(totalSum).toBe(parseInt(newEntry.ammount) * 4);
   })
 })

--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -8,7 +8,7 @@ import RowLink from './common/RowLink';
 import ScreenTitle from './common/ScreenTitle';
 
 const incomesName = 'incomes';
-const outcomesName = 'outcomes';
+const expensesName = 'expenses';
 
 function TotalItem({ name, ammount, Icon, url }) {
   return (
@@ -32,17 +32,17 @@ function TotalItem({ name, ammount, Icon, url }) {
 
 function Results({ entries, baseUrl = '' }) {
   const incomesSum = getSum({ entryType: incomesName, entries: entries })
-  const outcomesSum = getSum({ entryType: outcomesName, entries: entries })
+  const expensesSum = getSum({ entryType: expensesName, entries: entries })
   const incomesUrl = `${baseUrl}/${incomesName}`;
-  const outcomesUrl = `${baseUrl}/${outcomesName}`;
+  const expensesUrl = `${baseUrl}/${expensesName}`;
   const summaryUrl = `${baseUrl}/summary`;
-  const totalSum = calculateTotal(incomesSum, outcomesSum);
+  const totalSum = calculateTotal(incomesSum, expensesSum);
 
   return (
     <React.Fragment>
       <ScreenTitle screenTitle='Monthly Income/Expenses' />
       <TotalItem name='Incomes' ammount={incomesSum} url={incomesUrl} Icon={IconSignIn} />
-      <TotalItem name='Expenses' ammount={outcomesSum} url={outcomesUrl} Icon={IconSignOut} />
+      <TotalItem name='Expenses' ammount={expensesSum} url={expensesUrl} Icon={IconSignOut} />
       <RowLink to={summaryUrl} title='Summary' className='results-total'>
         <Col xs={12}>
           {`Savings: ${totalSum}`}

--- a/src/components/common/ExpensesManager/AddEntry/AddEntry.js
+++ b/src/components/common/ExpensesManager/AddEntry/AddEntry.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import CategorySelector from '../CategorySelector';
 import { connect } from 'react-redux';
-import { addIncome, addOutcome } from '../../../../redux/expensesManager/actionCreators';
+import { addIncome, addExpense } from '../../../../redux/expensesManager/actionCreators';
 import { getEntryModel, getEntryCategoryOption } from '../../../../helpers/entriesHelper'; 
 
 import { withRouter } from 'react-router-dom';
@@ -9,7 +9,7 @@ import { withRouter } from 'react-router-dom';
 const getActionFromEntryType = ({ entryType, props }) => {
   const entryTypeToActionDictionary = {
     income: props['onAddIncome'],
-    outcome: props['onAddOutcome']
+    expense: props['onAddExpense']
   };
 
   return entryTypeToActionDictionary[entryType];
@@ -76,7 +76,7 @@ const mapStateToProps = state => ({
 
 const mapActionToProps = dispatch => ({
   onAddIncome: income => dispatch(addIncome(income)),
-  onAddOutcome: expense => dispatch(addOutcome(expense))
+  onAddExpense: expense => dispatch(addExpense(expense))
 });
 
 export default connect(mapStateToProps, mapActionToProps)(withRouter(AddEntry));

--- a/src/components/common/ExpensesManager/Summaries/EntriesSummary.test.js
+++ b/src/components/common/ExpensesManager/Summaries/EntriesSummary.test.js
@@ -11,8 +11,8 @@ jest.mock('../helpers/entriesHelper');
 describe('EntriesSummary', () => {
   const entries = [
     { ammount: 12, type: 'imcome', description: 'My description', category: 'Salary' },
-    { ammount: -2, type: 'outcome', description: 'My description', category: 'Food' },
-    { ammount: -7, type: 'outcome', description: 'My description', category: 'Food' },
+    { ammount: -2, type: 'expense', description: 'My description', category: 'Food' },
+    { ammount: -7, type: 'expense', description: 'My description', category: 'Food' },
     { ammount: 12, type: 'imcome', description: 'My description', category: 'Salary' }
   ];
 

--- a/src/components/common/ExpensesManager/Summaries/Summary.js
+++ b/src/components/common/ExpensesManager/Summaries/Summary.js
@@ -17,10 +17,10 @@ class Summary extends Component {
   getFilteredEntries = filter => {
     const entriesSummary = {
       incomes: <EntriesSummary entries={this.props.entries['incomes']} name='Incomes' />,
-      outcomes: <EntriesSummary entries={this.props.entries['outcomes']} name='Outcomes' />
+      expenses: <EntriesSummary entries={this.props.entries['expenses']} name='Expenses' />
     }
     
-    return entriesSummary[filter] || <EntriesSummary entries={[...this.props.entries.incomes, ...this.props.entries.outcomes]} name='Summary' />
+    return entriesSummary[filter] || <EntriesSummary entries={[...this.props.entries.incomes, ...this.props.entries.expenses]} name='Summary' />
   }
 
   render() {
@@ -28,9 +28,9 @@ class Summary extends Component {
       <div>
         <form>
           <select name='filter' value={this.state.filter} onChange={this.handleChange}>
-            <option value=''>All incomes and outcomes</option>
+            <option value=''>All incomes and expenses</option>
             <option value='incomes'>Incomes</option>
-            <option value='outcomes'>Outcomes</option>
+            <option value='expenses'>Expenses</option>
           </select>
         </form>
         {this.getFilteredEntries(this.state.filter)}

--- a/src/helpers/entriesHelper.js
+++ b/src/helpers/entriesHelper.js
@@ -22,7 +22,7 @@ function getEntryModel(entryType) {
 
 function getEntryCategoryOption(entryType) {
   const categoryOptions = {
-    outcome: [
+    expense: [
       { name: 'Food', value: 'food' },
       { name: 'House', value: 'house' }
     ],

--- a/src/redux/expensesManager/actionCreators.js
+++ b/src/redux/expensesManager/actionCreators.js
@@ -1,3 +1,3 @@
 import { ActionCreators } from './actions';
 
-export const { addOutcome, addIncome, categoryChange } = ActionCreators();
+export const { addExpense, addIncome, categoryChange } = ActionCreators();

--- a/src/redux/expensesManager/actions.js
+++ b/src/redux/expensesManager/actions.js
@@ -2,7 +2,7 @@ export const ADD_OUTCOME = 'ADD_OUTCOME';
 export const ADD_INCOME = 'ADD_INCOME';
 export const CATEGORY_CHANGE = 'CATEGORY_CHANGE'
 
-const AddOutcome = () => expense => ({
+const AddExpense = () => expense => ({
   type: ADD_OUTCOME, payload: expense
 });
 
@@ -17,7 +17,7 @@ const CategoryChange = () => categoryValue => ({
 })
 
 export const ActionCreators = () => ({
-  addOutcome: AddOutcome(),
+  addExpense: AddExpense(),
   addIncome: AddIncome(),
   categoryChange: CategoryChange()
 });

--- a/src/redux/expensesManager/reducer.js
+++ b/src/redux/expensesManager/reducer.js
@@ -5,7 +5,7 @@ import { ADD_OUTCOME, ADD_INCOME, CATEGORY_CHANGE } from './actions';
 const initialState = {
   entries: {
     incomes: [],
-    outcomes: []
+    expenses: []
   },
   category: ''
 }
@@ -32,7 +32,7 @@ export const reducer = (state = initialState, action) => {
   switch (type) {
     case ADD_OUTCOME: return addEntry({
         entry: payload,
-        entryType: 'outcomes',
+        entryType: 'expenses',
         state
       });
     case ADD_INCOME: return addEntry({


### PR DESCRIPTION
# Description

A simple pull request remove the gap between the terminology in which I was using the word "outcomes" instead of "expenses" which was not part of the ubiquitous language of the application.